### PR TITLE
Macで動かすための調整

### DIFF
--- a/Assets/VRoid2STYLY/Scripts/Editor/CreateAnimator.cs
+++ b/Assets/VRoid2STYLY/Scripts/Editor/CreateAnimator.cs
@@ -67,7 +67,7 @@ public class CreateAnimator : MonoBehaviour
     //[MenuItem("MyMenu/Import file")]
     public static void Import()
     {
-        string path = EditorUtility.OpenFilePanel("Select file to import", "", "*");
+        string path = EditorUtility.OpenFilePanel("Select file to import", "", "vrm");
         if(path == "" || path == null)
         {
             return;


### PR DESCRIPTION
Mac上のUnityで動かした場合、VRMファイルの選択ができなかったので、明示的にVRMファイルを指定しました。